### PR TITLE
update ark dependencies to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tagged-base64"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["John D. Corbett <corbett@pictographer.com>"]
 edition = "2021"
 description = "User-oriented format for binary data. Tagged Base64 is intended to be used in user interfaces including URLs and text to be copied and pasted without the need for additional encoding, such as quoting or escape sequences."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ wasm-debug = ["dep:console_error_panic_hook"]
 build-cli = ["dep:clap"]
 
 [dependencies]
-ark-serialize = { version = "0.3.0", optional = true, default-features = false, features = ["derive"] }
+ark-serialize = { version = "0.4.0", optional = true, default-features = false, features = ["derive"] }
 base64 = "0.13.0"
 crc-any = { version = "2.4.1", default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -45,7 +45,7 @@ web-sys = { version = "0.3.49", optional = true, features = ["console", "Headers
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
-ark-std = { version = "0.3.0", default-features = false }
+ark-std = { version = "0.4.0", default-features = false }
 bincode = "1.3"
 getrandom = { version = "0.2", features = ["js"] }
 quickcheck = "1.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,26 +1,17 @@
 [package]
 name = "tagged-base64-macros"
 description = "Procedural macros associated with tagged-base64"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 proc-macro = true
 
 [features]
-default-features = ["serde"]
+default = ["serde"]
 serde = []
 
 [dependencies]
-ark-std = { version = "0.3.0", default-features = false }
 syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
-
-[dev-dependencies]
-ark-serialize = { version = "0.3.0", default-features = false, features = ["derive"] }
-ark-bls12-381 = { version = "0.3.0", default-features = false, features = ["curve"] }
-bincode = { version = "1.3.3", default-features = false }
-rand_chacha = { version = "0.3.1" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.61"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -127,7 +127,7 @@ pub fn tagged(args: TokenStream, input: TokenStream) -> TokenStream {
             type Error = tagged_base64::Tb64Error;
             fn try_from(t: &tagged_base64::TaggedBase64) -> Result<Self, Self::Error> {
                 if t.tag() == <#name #ty_generics as tagged_base64::Tagged>::tag() {
-                    <Self as CanonicalDeserialize>::deserialize(t.as_ref())
+                    <Self as CanonicalDeserialize>::deserialize_uncompressed_unchecked(t.as_ref())
                         .map_err(|_| tagged_base64::Tb64Error::InvalidData)
                 } else {
                     Err(tagged_base64::Tb64Error::InvalidTag)
@@ -148,7 +148,7 @@ pub fn tagged(args: TokenStream, input: TokenStream) -> TokenStream {
         {
             fn from(x: &#name #ty_generics) -> Self {
                 let mut bytes = ark_std::vec![];
-                CanonicalSerialize::serialize(x, &mut bytes).unwrap();
+                CanonicalSerialize::serialize_compressed(x, &mut bytes).unwrap();
                 Self::new(&<#name #ty_generics as tagged_base64::Tagged>::tag(), &bytes).unwrap()
             }
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -17,6 +17,13 @@ use syn::{parse_macro_input, AttributeArgs, Item, Meta, NestedMeta};
 /// this macro will serialize the type as bytes for binary encodings and as base 64 for human
 /// readable encodings.
 ///
+/// This macro takes at least one arguments:
+/// * The first argument should be the tag, as a string literal or expression.
+/// * By default, the derived implementation invokes `CanonicalSerialize` and `CanonicalDeserialize`
+///   with `uncompressed` and `unchecked` flags.
+/// * If `compressed` and/or `checked` flags are presented, the derived implementation will behave
+///   accordingly.
+///
 /// Specifically, this macro does 4 things when applied to a type definition:
 /// * It adds `#[derive(Serialize, Deserialize)]` to the type definition, along with serde
 ///   attributes to serialize using [TaggedBase64].
@@ -49,7 +56,7 @@ use syn::{parse_macro_input, AttributeArgs, Item, Meta, NestedMeta};
 /// # use ark_std::UniformRand;
 /// # use tagged_base64_macros::tagged;
 /// # use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
-/// # #[tagged("PRIM")]
+/// # #[tagged("PRIM", compressed)]
 /// # #[derive(Clone, CanonicalSerialize, CanonicalDeserialize, /* any other derives */)]
 /// # struct CryptoPrim(ark_bls12_381::Fr);
 /// # let crypto_prim = CryptoPrim(ark_bls12_381::Fr::rand(&mut ChaChaRng::from_seed([42; 32])));
@@ -61,7 +68,7 @@ use syn::{parse_macro_input, AttributeArgs, Item, Meta, NestedMeta};
 /// # use ark_std::UniformRand;
 /// # use tagged_base64_macros::tagged;
 /// # use rand_chacha::{ChaChaRng, rand_core::SeedableRng};
-/// # #[tagged("PRIM")]
+/// # #[tagged("PRIM", compressed, checked)]
 /// # #[derive(Clone, CanonicalSerialize, CanonicalDeserialize, /* any other derives */)]
 /// # struct CryptoPrim(ark_bls12_381::Fr);
 /// # let crypto_prim = CryptoPrim(ark_bls12_381::Fr::rand(&mut ChaChaRng::from_seed([42; 32])));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,8 @@ impl<'a> Deserialize<'a> for TaggedBase64 {
             // Otherwise, this is a binary format; deserialize bytes and then convert the bytes to
             // TaggedBase64 using CanonicalDeserialize.
             let bytes = <Vec<u8> as Deserialize>::deserialize(deserializer)?;
-            CanonicalDeserialize::deserialize_uncompressed_unchecked(bytes.as_slice()).map_err(D::Error::custom)
+            CanonicalDeserialize::deserialize_uncompressed_unchecked(bytes.as_slice())
+                .map_err(D::Error::custom)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,11 +286,7 @@ impl TaggedBase64 {
     /// Returns true for characters permitted in URL-safe base64 encoding,
     /// and false otherwise.
     pub fn is_safe_base64_ascii(c: char) -> bool {
-        ('a'..='z').contains(&c)
-            || ('A'..='Z').contains(&c)
-            || ('0'..='9').contains(&c)
-            || (c == '-')
-            || (c == '_')
+        c.is_ascii_alphanumeric() || (c == '-') || (c == '_')
     }
 
     /// Checks that an ASCII byte is safe for use in the tag of a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl Serialize for TaggedBase64 {
         } else {
             // For binary formats, convert to bytes (using CanonicalSerialize) and write the bytes.
             let mut bytes = vec![];
-            CanonicalSerialize::serialize(self, &mut bytes).map_err(S::Error::custom)?;
+            CanonicalSerialize::serialize_compressed(self, &mut bytes).map_err(S::Error::custom)?;
             Serialize::serialize(&bytes, serializer)
         }
     }
@@ -114,7 +114,7 @@ impl<'a> Deserialize<'a> for TaggedBase64 {
             // Otherwise, this is a binary format; deserialize bytes and then convert the bytes to
             // TaggedBase64 using CanonicalDeserialize.
             let bytes = <Vec<u8> as Deserialize>::deserialize(deserializer)?;
-            CanonicalDeserialize::deserialize(bytes.as_slice()).map_err(D::Error::custom)
+            CanonicalDeserialize::deserialize_uncompressed_unchecked(bytes.as_slice()).map_err(D::Error::custom)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl<'a> Deserialize<'a> for TaggedBase64 {
             // Otherwise, this is a binary format; deserialize bytes and then convert the bytes to
             // TaggedBase64 using CanonicalDeserialize.
             let bytes = <Vec<u8> as Deserialize>::deserialize(deserializer)?;
-            CanonicalDeserialize::deserialize_uncompressed_unchecked(bytes.as_slice())
+            CanonicalDeserialize::deserialize_compressed_unchecked(bytes.as_slice())
                 .map_err(D::Error::custom)
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -442,6 +442,18 @@ fn one_bit_corruption_quickcheck(tag: u16, data: (Vec<u8>, u8), bit_to_flip: u16
 #[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
 struct Blob(Vec<u8>);
 
+#[tagged("BLOB", compressed)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+struct BlobCompressed(Vec<u8>);
+
+#[tagged("BLOB", checked)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+struct BlobChecked(Vec<u8>);
+
+#[tagged("BLOB", compressed, checked)]
+#[derive(Clone, Debug, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
+struct BlobCompressedChecked(Vec<u8>);
+
 #[test]
 fn test_tagged() {
     let bytes = (0..100).collect();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -33,7 +33,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 fn base64_sanity() {
     let hello = b"hello rustaceans";
     let encoded = encode_config(hello, TB64_CONFIG);
-    let decoded = decode_config(&encoded, TB64_CONFIG).unwrap();
+    let decoded = decode_config(encoded, TB64_CONFIG).unwrap();
     assert_eq!(&hello.to_vec(), &decoded);
     assert_eq!(
         str::from_utf8(hello).unwrap(),
@@ -143,7 +143,7 @@ fn test_display() {
 /// - Generated string can be parsed
 /// - Accessors and parsed string match the supplied values
 fn check_tb64(tag: &str, value: &[u8]) {
-    let mut tb64 = TaggedBase64::new(tag, &value).unwrap();
+    let mut tb64 = TaggedBase64::new(tag, value).unwrap();
     let str = format!("{}", &tb64);
 
     // use web_sys;
@@ -157,7 +157,7 @@ fn check_tb64(tag: &str, value: &[u8]) {
     assert_eq!(parsed.tag(), tag);
 
     // Do we get back the binary value we supplied?
-    assert!(is_equal(&parsed.value(), &value));
+    assert!(is_equal(&parsed.value(), value));
 
     // If we change the tag, do we get back the new tag?
     tb64.set_tag("foo");
@@ -213,13 +213,13 @@ fn tagged_base64_parse() {
     assert!(TaggedBase64::new("Σ", b"").is_err());
 
     // Note, u128::MAX is 340282366920938463463374607431768211455
-    check_tb64("PK", &u128::MAX.to_string().as_bytes());
+    check_tb64("PK", u128::MAX.to_string().as_bytes());
 
     // Is ten copies of u128::MAX a big enough test?
     let z = u128::MAX;
     check_tb64(
         "many-bits",
-        &format!("{}{}{}{}{}{}{}{}{}{}", z, z, z, z, z, z, z, z, z, z).as_bytes(),
+        format!("{}{}{}{}{}{}{}{}{}{}", z, z, z, z, z, z, z, z, z, z).as_bytes(),
     );
 
     check_tb64("TX", b"transaction identifier goes here");
@@ -265,7 +265,7 @@ fn test_tagged_base64_new() {
 fn tag_accessor() {
     let tag = "Tag47";
     let bits = b"Just some bits";
-    let tb64 = TaggedBase64::new(&tag, bits).unwrap();
+    let tb64 = TaggedBase64::new(tag, bits).unwrap();
     assert_eq!(tb64.tag(), tag);
     assert_eq!(tb64.value(), bits);
 }
@@ -444,7 +444,7 @@ struct Blob(Vec<u8>);
 
 #[test]
 fn test_tagged() {
-    let bytes = (0..100).into_iter().collect();
+    let bytes = (0..100).collect();
     let b = Blob(bytes);
     let t = TaggedBase64::from(&b);
     assert!(t.to_string().starts_with("BLOB~"));
@@ -453,7 +453,7 @@ fn test_tagged() {
 
 #[test]
 fn test_serde_json() {
-    let bytes = (0..100).into_iter().collect::<Vec<_>>();
+    let bytes = (0..100).collect::<Vec<_>>();
     let t = TaggedBase64::new("TAG", &bytes).unwrap();
     let s = serde_json::to_string(&t).unwrap();
     assert!(s.starts_with("\"TAG~"));
@@ -462,7 +462,7 @@ fn test_serde_json() {
 
 #[test]
 fn test_serde_bincode() {
-    let bytes = (0..100).into_iter().collect::<Vec<_>>();
+    let bytes = (0..100).collect::<Vec<_>>();
     let t = TaggedBase64::new("TAG", &bytes).unwrap();
     assert_eq!(
         t,


### PR DESCRIPTION
needed to migrate jellyfish to arkworks 0.4