### PR TITLE
Remove the `wasm-bindgen` feature from default

### DIFF
--- a/tagged-base64/Cargo.toml
+++ b/tagged-base64/Cargo.toml
@@ -14,7 +14,7 @@ name = "tagged-base64"
 required-features = ["build-cli"]
 
 [features]
-default = ["ark-serialize", "serde", "wasm-bindgen"]
+default = ["ark-serialize", "serde"]
 ark-serialize = ["dep:ark-serialize"]
 serde = ["dep:serde", "tagged-base64-macros/serde"]
 wasm-bindgen = ["dep:wasm-bindgen"]


### PR DESCRIPTION
### This PR:
It seems unnecessary to use `wasm-bindgen` in many cases.

### This PR does not:
Change any logic