### PR TITLE
upgrade to arkwork 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "MIT"
@@ -12,9 +12,8 @@ members = [
 ]
 
 [workspace.dependencies]
-ark-bls12-381 = "0.4"
-ark-serialize = { version = "0.4", default-features = false }
-ark-std = { version = "0.4", default-features = false }
+ark-serialize = { version = "0.5", default-features = false }
+ark-std = { version = "0.5", default-features = false }
 base64 = "0.22"
 rand_chacha = "0.3"
 serde = "1.0"

--- a/tagged-base64/Cargo.toml
+++ b/tagged-base64/Cargo.toml
@@ -46,7 +46,7 @@ web-sys = { version = "0.3.49", optional = true, features = ["console", "Headers
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dev-dependencies]
-ark-bls12-381 = { workspace = true }
+ark-bls12-381 = "0.5"
 bincode = "1.3"
 getrandom = { version = "0.2", features = ["js"] }
 quickcheck = "1.0"


### PR DESCRIPTION
Part of https://github.com/EspressoSystems/jellyfish/pull/827 where we want to upgrade to arkwork 0.5

I think we can release as a patch version bump?  even though arkwork 0.5 contains breaking changes, we are not re-exposing any of their types, so the macro should still work if the downstream user are depending on an older version of arkworks, would you agree? @jbearer 